### PR TITLE
Show default title if Item's title is empty #32

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,8 @@
 class Item < ActiveRecord::Base
   belongs_to :advent_calendar_item
   has_many :comments, dependent: :destroy
+
+  def title
+    self[:title].presence || I18n.t("activerecord.attributes.item.title_empty")
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
         comment: Comment
       item:
         title: Title
+        title_empty: No title
   controllers:
     attachments:
       create:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,6 +32,7 @@ ja:
         comment: コメント
       item:
         title: タイトル
+        title_empty: 無題
   controllers:
     attachments:
       create:

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe Item do
+  it "retuns title value if title is not empty" do
+    item = build(:item, title: "title")
+    expect(item.title).to eq("title")
+  end
+
   it "returns deafult value if title is empty" do
     item = build(:item, title: "")
     expect(item.title).to eq(I18n.t("activerecord.attributes.item.title_empty"))

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Item do
+  it "returns deafult value if title is empty" do
+    item = build(:item, title: "")
+    expect(item.title).to eq(I18n.t("activerecord.attributes.item.title_empty"))
+  end
+end


### PR DESCRIPTION
This PR is for issue #32 .

* Override read_attribute of `Item.title`. If title is empty, show default title.
* Add empty title locale
* Add rspec test

@kyow 
I'm very happy if you review it and  give me any suggestions. :pray: 
If there's no problem, press "Merge pull request" button. 