### PR TITLE
add missing dependency: therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.0.0'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer',  platforms: :ruby
+gem 'therubyracer',  platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'


### PR DESCRIPTION
I got following error when running application after clean install with bundle.
I found this is because lack of JavaScript environment.
This PR solves missing dependency with Gemfile modification.

Thanks.

### Error message
```
$ bundle exec rails s
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:84:in `rescue in block (2 levels) in require': There was an error while trying to
 load the gem 'uglifier'. (Bundler::GemRequireError)
Gem Load Error is: Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes.
Backtrace for gem load error is:
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/execjs-2.2.2/lib/execjs/runtimes.rb:51:in `autodetect'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/execjs-2.2.2/lib/execjs.rb:5:in `<module:ExecJS>'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/execjs-2.2.2/lib/execjs.rb:4:in `<top (required)>'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/uglifier-2.5.3/lib/uglifier.rb:3:in `require'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/uglifier-2.5.3/lib/uglifier.rb:3:in `<top (required)>'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:81:in `require'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:76:in `each'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:76:in `block in require'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:65:in `each'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:65:in `require'
/home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler.rb:114:in `require'
/mnt/c/works/codes/radvent/config/application.rb:7:in `<top (required)>'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:79:in `require'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:79:in `block in server'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:76:in `tap'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:76:in `server'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
/mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands.rb:17:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Bundler Error Backtrace:
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:80:in `block (2 levels) in require'
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:76:in `each'
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:76:in `block in require'
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:65:in `each'
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:65:in `require'
        from /home/yasu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.16.0/lib/bundler.rb:114:in `require'
        from /mnt/c/works/codes/radvent/config/application.rb:7:in `<top (required)>'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:79:in `require'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:79:in `block in server'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:76:in `tap'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:76:in `server'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
        from /mnt/c/works/codes/radvent/vendor/bundle/ruby/2.1.0/gems/railties-4.1.7/lib/rails/commands.rb:17:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```